### PR TITLE
Release version 0.5.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "gmaps" %}
-{% set version = "0.5.1" %}
-{% set sha256 = "c9801aef5fc4632b54798e646919cbcba3308dfff628a28e151d5f85fe9821a1" %}
+{% set version = "0.5.2" %}
+{% set sha256 = "38b06d096df17e786a097fc8a80fd3a04ffa788af29d0daa4c31defb8388b242" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
This is a bugfix release.
 - Bounds are now calculated correctly when there are multiple layers (PR 148).
 - Latitude bounds cannot exceed the maximum allowed by Google Maps (PR 149).
 - Alpha values of 1.0 are now allowed.