### PR TITLE
Release version 0.5.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "gmaps" %}
-{% set version = "0.5.2" %}
-{% set sha256 = "38b06d096df17e786a097fc8a80fd3a04ffa788af29d0daa4c31defb8388b242" %}
+{% set version = "0.5.4" %}
+{% set sha256 = "1f7cdad30ae45fa900c5f4e0c0aeebe19d2235ac1cb3530dcb6c1b0120d32704" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
Version 0.5.4
=============

This release:
 - Fixes a bug where bounds were incorrectly calculated for the case where there was a single point in the data (PR 160).
 - Allows setting the travel mode in the directions layer (PR 157).
 - Fixes the release script to use a fork of the conda-forge feedstock (PR 156).