### PR TITLE
Lower bounds on geojson and ipywidgets were wrong.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,8 +22,8 @@ requirements:
     - jupyter
   run:
     - python
-    - ipywidgets >=6.0.0
-    - geojson >=1.3.4
+    - ipywidgets >=7.0.0
+    - geojson >=2.0.0
 
 test:
   imports:


### PR DESCRIPTION
These hadn't been updated for geojson 2 and ipywidgets 7.