### PR TITLE
Release version 0.7.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "gmaps" %}
-{% set version = "0.6.2" %}
-{% set sha256 = "f966e36459a8b9881aa92f00e6ad42d13ae0a2cf5f44b9646397651c308d7cf0" %}
+{% set version = "0.7.0" %}
+{% set sha256 = "3f2242c3eeea35130e7ede07bb671914f43227a5d6185934a0b0b5f41e279440" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
- This minor release adds a drawing layer, giving the user the ability to add
arbitrary lines, markers and polygons to a map. The developer can bind callbacks
that are run when a feature is added, allowing the development of complex, widgets-
based application on top of jupyter-gmaps (PR 183).
- It fixes a bug where the bounds were incorrectly calculated when two longitudes coincided (PR 204).
- It fixes a bug where, for single latitudes, the returned bounds could stretch beyond what Google Maps allows (PR 204)