### PR TITLE
Release version 0.7.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "gmaps" %}
-{% set version = "0.7.3" %}
-{% set sha256 = "9bae665e87c98d7592c9f41aef13aecd1f62ccb3126c24ced59c610491772a7d" %}
+{% set version = "0.7.4" %}
+{% set sha256 = "35e58737c61df5a0a891408e813e0b5de0a2bf47407ec8fc1f89943ddcc5dd5d" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
This minor release:
 - allows setting which map type we use (PR 232)
 - allows setting how the map interacts with the webpage, in terms of capturing scroll events (PR 232)
 - allows setting the style of polygons on the drawing layer (PR 229)
 - fixes a bug that stopped the drawing layer from being downloadable as a PNG (PR 227)