### PR TITLE
Release version 0.8.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "gmaps" %}
-{% set version = "0.7.4" %}
-{% set sha256 = "35e58737c61df5a0a891408e813e0b5de0a2bf47407ec8fc1f89943ddcc5dd5d" %}
+{% set version = "0.8.0" %}
+{% set sha256 = "50da8504211f5d06783081e024f30ec2ba3c0007de956a99c4d1afe3f80d90ac" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
This minor release:

- Changes the directions layer widget to add the `start`, `end` and `waypoints`
  traitlets. This deprecates the `data` traitlet, scheduled for removal in 0.9.0.
  (PR 236).
- The directions layer now reacts to changes in start, end and waypoints by
  re-calculating the route (PR 239)
- The directions layer now supports styling the route (PR 247)
- Errors in the direction layer are now shown in the error box, rather than as
  an uncatchable exception (PR 242)
- Errors authenticating result in an error message that replaces the map,
  rather than the cryptic 'Oops, something went wrong' default that Google Maps
  provides (PR 240)
- Adds style to error box (PR 243)
- Removes the deprecated `data` traitlet from the Heatmap and WeightedHeatmap
  widgets. See PR 249 for a migration pathway. (PR 249)
- Introduces the Opacity traitlet for encoding stroke and fill opacities (PR 248)