### PR TITLE
Release version 0.8.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   noarch: python
-  number: 1
+  number: 0
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "gmaps" %}
-{% set version = "0.8.0" %}
-{% set sha256 = "50da8504211f5d06783081e024f30ec2ba3c0007de956a99c4d1afe3f80d90ac" %}
+{% set version = "0.8.1" %}
+{% set sha256 = "37ed443ac3c1b964f29b39cd4dfc783a97d7274d6856467ccc63aa43396b7f65" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a fork of the feedstock to propose changes
~Bumped the build number (if the version is unchanged)~
* [X] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [X] Ensured the license file is being packaged. Note -- the license file is packaged in the `gmaps` sdist. Is that what this means? Or should there be a license on this package?

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Version 0.8.1
=============

This release:
- adds the tilt option to maps (PR 253).
- fixes passing tilt and stroke opacity attributes to heatmap (PR 263).
- fixes an issue on JupyterLab where the color of output cells was 
  changed to grey when built with jupyter-gmaps (PR 268).
- updates the release process to use twine (PR 269).
